### PR TITLE
Adds Cypress run command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+cypress/videos
+cypress/screenshots

--- a/cypress/integration/title.test.js
+++ b/cypress/integration/title.test.js
@@ -1,0 +1,6 @@
+describe('When Accessing the Application', () => {
+    it('should have a page title of Senf.koeln', () => {
+        cy.visit('localhost:3000/');
+        cy.title().should('include', 'Senf.koeln');
+    });
+});

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "super": "superstatic src",
-    "cypress": "cypress open"
+    "cypress": "cypress open",
+    "cypress:run": "cypress run"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "super": "superstatic src",
-    "cypress": "cypress open",
-    "cypress:run": "cypress run"
+    "cy:open": "cypress open",
+    "cy:run": "cypress run"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
Closes #76 

This PR also adds a few changes.

- Create a sample test to check Cypress runs correctly.
- Renamed npm script:
 `cypress` -> `cy:open` runs `cypress open`
- Added npm script:
`cy:run` runs `cypress run`
- Update .gitignore in order to ignore cypress outputs