### PR TITLE
Add .idea to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log*
 
 cypress/videos
 cypress/screenshots
+
+# IDE's 
+.idea


### PR DESCRIPTION
When using WebStorm editor, a folder .idea is created. It should be included in the project